### PR TITLE
OvmfPkg/XenPlatformPei: Allocate more memory when PEI FV  is shadowed

### DIFF
--- a/SOURCES/0001-OvmfPkg-XenPlatformPei-Allocate-more-memory-when-PEI.patch
+++ b/SOURCES/0001-OvmfPkg-XenPlatformPei-Allocate-more-memory-when-PEI.patch
@@ -1,0 +1,55 @@
+From 33cb33d449928e50eb7aa2fa34f1bdae9a6c40b2 Mon Sep 17 00:00:00 2001
+From: Anthony PERARD <anthony.perard@vates.tech>
+Date: Mon, 17 Feb 2025 16:05:48 +0100
+Subject: [PATCH 1/1] OvmfPkg/XenPlatformPei: Allocate more memory when PEI FV
+ is shadowed
+
+Patch "OVMF: Shadow PEI for consistent measurements" make a pristine
+copy of the PEI FV and create a Migrated FV Info HOB. This lead to the
+allocation of a second set of 1:1 page tables. Sometime, there's not
+enough space for that second set, so allocate space for it.
+
+Usually, the page tables don't take much space and can fit in the
+extra 64MB of miscellaneous allocation. But in some case, like a
+machine that don't report 1GB page support, we are going to need a lot
+more pages to map a machine with a physical memory address width of 45
+with only 2MB page.
+
+This second set of 1:1 mapping is created by
+MemoryDiscoveredPpiNotifyCallback() in UefiCpuPkg/CpuMpPei module when
+there's a MigrateFvInfo HOB.
+
+This patch isn't needed upstream as commit 56ad09ba75be
+("UefiCpuPkg/CpuMpPei: Conditionally enable PAE paging in 32bit mode")
+changed when the page table is created, and mean no more second set of
+1:1 page tables.
+
+Signed-off-by: Anthony PERARD <anthony.perard@vates.tech>
+---
+ OvmfPkg/XenPlatformPei/MemDetect.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/OvmfPkg/XenPlatformPei/MemDetect.c b/OvmfPkg/XenPlatformPei/MemDetect.c
+index d412d1f4db6f..0ecddf5d963c 100644
+--- a/OvmfPkg/XenPlatformPei/MemDetect.c
++++ b/OvmfPkg/XenPlatformPei/MemDetect.c
+@@ -256,6 +256,16 @@ GetPeiMemoryCap (
+                (PdpEntries + 1) * Pml4Entries + 1;
+   ASSERT (TotalPages <= 0x40201);
+ 
++  //
++  // If PcdOvmfShadowPeiBase is set, we create a gEdkiiMigratedFvInfoGuid
++  // in XenPlatformPei. This lead to the creation of a second set of page
++  // tables in MemoryDiscoveredPpiNotifyCallback() in CpuMpPei. Allocate
++  // space for it.
++  //
++  if (PcdGet32 (PcdOvmfShadowPeiBase)) {
++    TotalPages *= 2;
++  }
++
+   //
+   // Add 64 MB for miscellaneous allocations. Note that for
+   // mPhysMemAddressWidth values close to 36, the cap will actually be
+-- 
+Anthony PERARD
+

--- a/SPECS/edk2.spec
+++ b/SPECS/edk2.spec
@@ -75,6 +75,7 @@ Patch42: add-debugging-info.patch
 
 # XCP-ng patches
 Patch1001: UefiCpuPkg-CpuMpPei-Workaround-page-table-allocation.patch
+Patch1002: 0001-OvmfPkg-XenPlatformPei-Allocate-more-memory-when-PEI.patch
 
 %if 0%{?xenserver} < 9
 BuildRequires: devtoolset-11-binutils

--- a/SPECS/edk2.spec
+++ b/SPECS/edk2.spec
@@ -20,7 +20,7 @@
 Name: edk2
 Summary: EFI Development Kit II
 Version: 20220801
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 
 License: BSD and MIT
 URL: https://github.com/tianocore/edk2
@@ -194,6 +194,9 @@ cp OvmfPkg/License.txt License.ovmf
 
 
 %changelog
+* Wed Feb 26 2025 anthony.perard@vates.tech - 20220801-1.7.7.2
+- Fix for ENOMEM error when allocating page tables.
+
 * Fri Aug 09 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 20220801-1.7.7.1
 - Sync with 20220801-1.7.7
 - *** Upstream changelog ***


### PR DESCRIPTION
XCPNG-486: Fix for ENOMEM error in DxeIplPeim

This patch fix an error that materialise as:

> AllocatePages failed: No 0x8400 Pages is available.
> There is only left 0x3AA8 pages memory resource to be allocated.
> ERROR: Out of aligned pages

One some system, with XCP-ng's OvmfXen, we can be in a position were
PhysicalAddressBits == 45 but Page1GSupport==FALSE, which lead to a
huge amount of memory needed to allocate the page tables:

> AddressBits=45 5LevelPaging=0 1GPage=0
> Pml5=1 Pml4=64 Pdp=512 TotalPage=32833

The added patch explain where the allocated memory is gone, and why,
and allocate enough space for it.